### PR TITLE
Fixed link to contribution guide

### DIFF
--- a/_posts/2016-04-18-firstwiki-returns.md
+++ b/_posts/2016-04-18-firstwiki-returns.md
@@ -23,5 +23,5 @@ copied to this site -- I didn't want to directly copy it wholesale, but would
 rather have people curate the content and only put the interesting/relevant data
 here.
 
-See our [contribution guide](/docs/contributing/), and feel free to issue a
+See our [contribution guide](/docs/contributing), and feel free to issue a
 pull request with your changes! 


### PR DESCRIPTION
Removed the slash at the end of  /docs/contributing/